### PR TITLE
Online Accounts: support any services of type "calendar"

### DIFF
--- a/com.ubuntu.calendar_calendar.application
+++ b/com.ubuntu.calendar_calendar.application
@@ -3,13 +3,10 @@
   <description>Calendar</description>
   <translations>calendar-sync</translations>
 
-  <services>
-    <service id="google-caldav">
+  <service-types>
+    <service-type id="calendar">
       <description>Syncronize your calendar</description>
-    </service>
-    <service id="owncloud-caldav">
-      <description>Syncronize your calendar</description>
-    </service>
-  </services>
+    </service-type>
+  </service-types>
 
 </application>


### PR DESCRIPTION
This allows us to avoid listing all supported services.