### PR TITLE
Issue11 working hours bg color

### DIFF
--- a/manifest.json.in
+++ b/manifest.json.in
@@ -18,7 +18,7 @@
     "maintainer": "UBports <community@ubports.com>",
     "name": "@PROJECT_NAME@",
     "title": "Calendar",
-    "version": "0.6.3",
+    "version": "0.7.0",
     "x-test": {
         "autopilot": {
             "autopilot_module": "@AUTOPILOT_DIR@",

--- a/manifest.json.in
+++ b/manifest.json.in
@@ -18,7 +18,7 @@
     "maintainer": "UBports <community@ubports.com>",
     "name": "@PROJECT_NAME@",
     "title": "Calendar",
-    "version": "0.7.0",
+    "version": "0.7.1",
     "x-test": {
         "autopilot": {
             "autopilot_module": "@AUTOPILOT_DIR@",

--- a/qml/DayView.qml
+++ b/qml/DayView.qml
@@ -158,7 +158,7 @@ PageWithBottomEdge {
 
             property var startDay: currentDate
             //This is used to scroll all view together when currentItem scrolls
-            property real childContentY;
+            property real childScrollHour;
             property real hourItemHeight: units.gu(4)
 
             anchors {
@@ -224,16 +224,16 @@ PageWithBottomEdge {
                 //get contentY value from PathView, if its not current Item
                 Binding{
                     target: timeLineView
-                    property: "contentY"
-                    value: dayViewPath.childContentY;
+                    property: "scrollHour"
+                    value: dayViewPath.childScrollHour;
                     when: !timeLineView.isCurrentItem
                 }
 
                 //set PathView's contentY property, if its current item
                 Binding{
                     target: dayViewPath
-                    property: "childContentY"
-                    value: timeLineView.contentY
+                    property: "childScrollHour"
+                    value: timeLineView.scrollHour
                     when: timeLineView.isCurrentItem
                 }
             }

--- a/qml/DayView.qml
+++ b/qml/DayView.qml
@@ -146,7 +146,7 @@ PageWithBottomEdge {
         minX: 1
         maxX: 1.1
         isInvertedX: true
-        onUpdateTargetX: { dayViewPinch.targetX = targetX }
+        onUpdateTargetX: { dayViewPinch.targetX = targetX; }
         onMaxHitX: { tabs.selectedTabIndex = weekTab.index; }
 
         targetY: dayViewPath.hourItemHeight
@@ -183,6 +183,7 @@ PageWithBottomEdge {
                 modelFilter: dayViewPage.model ? dayViewPage.model.filter : null
                 autoUpdate: dayViewPage.tabSelected && dayViewPage.active && PathView.isCurrentItem
                 hourItemHeight: Math.max(dayViewPath.hourItemHeight, timeLineView.hourItemHeightMin)
+                headerHeight: dayViewPath.anchors.topMargin
 
                 onPressAndHoldAt: {
                     dayViewPage.pressAndHoldAt(date, allDay)

--- a/qml/DayView.qml
+++ b/qml/DayView.qml
@@ -139,80 +139,103 @@ PageWithBottomEdge {
         createEventAt = eventAt
     }
 
-    PathViewBase{
-        id: dayViewPath
-        objectName: "dayViewPath"
+    PinchAreaBase {
+        id: dayViewPinch
 
-        property var startDay: currentDate
-        //This is used to scroll all view together when currentItem scrolls
-        property real childContentY;
+        targetX: 1
+        minX: 1
+        maxX: 1.1
+        isInvertedX: true
+        onUpdateTargetX: { dayViewPinch.targetX = targetX }
+        onMaxHitX: { tabs.selectedTabIndex = weekTab.index; }
 
-        anchors {
-            fill: parent
-            topMargin: header.height
-            bottomMargin: dayViewPage.bottomEdgeHeight
-        }
+        targetY: dayViewPath.hourItemHeight
+        onUpdateTargetY: { dayViewPath.hourItemHeight = targetY; }
 
-        delegate: TimeLineBaseComponent {
-            id: timeLineView
-            objectName: "DayComponent-"+index
+        PathViewBase {
+            id: dayViewPath
+            objectName: "dayViewPath"
 
-            width: parent.width
-            height: parent.height
+            property var startDay: currentDate
+            //This is used to scroll all view together when currentItem scrolls
+            property real childContentY;
+            property real hourItemHeight: units.gu(4)
 
-            type: ViewType.ViewTypeDay
-            isCurrentItem: PathView.isCurrentItem
-            isActive: !dayViewPath.moving && !dayViewPath.flicking
-            contentInteractive: PathView.isCurrentItem
-            startDay: anchorDate.addDays(dayViewPath.loopCurrentIndex + dayViewPath.indexType(index))
-            keyboardEventProvider: dayViewPath
-            modelFilter: dayViewPage.model ? dayViewPage.model.filter : null
-            autoUpdate: dayViewPage.tabSelected && dayViewPage.active && PathView.isCurrentItem
-
-            onPressAndHoldAt: {
-                dayViewPage.pressAndHoldAt(date, allDay)
+            anchors {
+                fill: parent
+                topMargin: header.height
+                bottomMargin: dayViewPage.bottomEdgeHeight
             }
 
-            Component.onCompleted: {
-                if(dayViewPage.tabSelected){
-                    idleScroll.restart()
+            delegate: TimeLineBaseComponent {
+                id: timeLineView
+                objectName: "DayComponent-"+index
+
+                width: parent.width
+                height: parent.height
+
+                type: ViewType.ViewTypeDay
+                isCurrentItem: PathView.isCurrentItem
+                isActive: !dayViewPath.moving && !dayViewPath.flicking
+                contentInteractive: PathView.isCurrentItem
+                startDay: anchorDate.addDays(dayViewPath.loopCurrentIndex + dayViewPath.indexType(index))
+                keyboardEventProvider: dayViewPath
+                modelFilter: dayViewPage.model ? dayViewPage.model.filter : null
+                autoUpdate: dayViewPage.tabSelected && dayViewPage.active && PathView.isCurrentItem
+                hourItemHeight: Math.max(dayViewPath.hourItemHeight, timeLineView.hourItemHeightMin)
+
+                onPressAndHoldAt: {
+                    dayViewPage.pressAndHoldAt(date, allDay)
                 }
-            }
 
-            Connections{
-                target: dayViewPage
-                onTabSelectedChanged: {
+                Component.onCompleted: {
                     if(dayViewPage.tabSelected){
-                        timeLineView.scrollToTime(new Date());
+                        idleScroll.restart()
                     }
                 }
-                onActiveChanged: {
-                    if (dayViewPage.active) {
+
+                Connections{
+                    target: dayViewPage
+                    onTabSelectedChanged: {
+                        if(dayViewPage.tabSelected){
+                            timeLineView.scrollToTime(new Date());
+                        }
+                    }
+                    onActiveChanged: {
+                        if (dayViewPage.active) {
+                            timeLineView.update()
+                        }
+                    }
+                    onEventSaved: {
+                        timeLineView.update()
+                    }
+                    onEventDeleted: {
                         timeLineView.update()
                     }
                 }
-                onEventSaved: {
-                    timeLineView.update()
-                }
-                onEventDeleted: {
-                    timeLineView.update()
-                }
-            }
 
-            //get contentY value from PathView, if its not current Item
-            Binding{
-                target: timeLineView
-                property: "contentY"
-                value: dayViewPath.childContentY;
-                when: !timeLineView.isCurrentItem
-            }
+                Binding{
+                    target: dayViewPinch
+                    property: "minY"
+                    value: timeLineView.hourItemHeightMin
+                    when: timeLineView.isCurrentItem
+                }
 
-            //set PathView's contentY property, if its current item
-            Binding{
-                target: dayViewPath
-                property: "childContentY"
-                value: timeLineView.contentY
-                when: timeLineView.isCurrentItem
+                //get contentY value from PathView, if its not current Item
+                Binding{
+                    target: timeLineView
+                    property: "contentY"
+                    value: dayViewPath.childContentY;
+                    when: !timeLineView.isCurrentItem
+                }
+
+                //set PathView's contentY property, if its current item
+                Binding{
+                    target: dayViewPath
+                    property: "childContentY"
+                    value: timeLineView.contentY
+                    when: timeLineView.isCurrentItem
+                }
             }
         }
     }

--- a/qml/EventBubble.qml
+++ b/qml/EventBubble.qml
@@ -37,7 +37,7 @@ Item{
     property bool isLiveEditing: false
     property Flickable flickable;
     property bool isEventBubble: true
-    property real minimumHeight: units.gu(4)
+    property real minimumHeight: fontMetrics.height
 
     // Event bubble style
     property alias titleText: eventTitle.text
@@ -54,6 +54,7 @@ Item{
 
     signal clicked(var event);
 
+    onMinuteHeightChanged: resize()
 
     // keep color up-to-date
     Connections {

--- a/qml/EventRepetition.qml
+++ b/qml/EventRepetition.qml
@@ -139,6 +139,13 @@ Page {
                 else {
                     rule.limit = undefined;
                 }
+
+                if (recurrenceOption.selectedIndex > 0 && recurrenceInterval.text !== "") {
+                    rule.interval = parseInt(recurrenceInterval.text);
+                }
+                else {
+                    rule.interval = 1;
+                }
             }
             else {
                 eventRoot.rule = null;
@@ -216,6 +223,31 @@ Page {
 
                     }
                 }
+            }
+        }
+
+        ListItem.Header {
+            text: i18n.tr("Interval of recurrence")
+            __foregroundColor: Theme.palette.normal.baseText
+            visible: recurrenceOption.selectedIndex != 0
+        }
+
+        TextField {
+            id: recurrenceInterval
+            objectName: "recurrenceInterval"
+
+            anchors {
+                left: parent.left
+                right: parent.right
+                margins: units.gu(2)
+            }
+
+            visible: recurrenceOption.selectedIndex != 0
+            validator: IntValidator{ bottom: 1; }
+            inputMethodHints: Qt.ImhDialableCharactersOnly
+
+            onTextChanged: {
+                backAction.enabled = !!text.trim()
             }
         }
 

--- a/qml/PinchAreaBase.qml
+++ b/qml/PinchAreaBase.qml
@@ -1,0 +1,105 @@
+import QtQuick 2.4
+
+PinchArea {
+    anchors.fill: parent
+    pinch.minimumRotation: 0
+    pinch.maximumRotation: 0
+    pinch.minimumScale: 1
+    pinch.maximumScale: 10
+
+    property var targetX: null
+    property var targetY: null
+    property var originalX
+    property var originalY
+    property var minX: null
+    property var maxX: null
+    property var minY: null
+    property var maxY: null
+    property int threshCountX: 0
+    property int threshCountY: 0
+    property bool isInvertedX: false
+    property bool isInvertedY: false
+
+    readonly property int threshold: 20
+
+    signal minHitX
+    signal maxHitX
+    signal minHitY
+    signal maxHitY
+    signal updateTargetX(real targetX);
+    signal updateTargetY(real targetY);
+
+    function isZoomAlongX(angle) {
+        return ( (angle < 45 && angle > -45) || (angle > 135 || angle < -135) );
+    }
+
+    function scaledX(scale) {
+        return (isInvertedX ? originalX*(1/scale) : originalX*scale);
+    }
+
+    function scaledY(scale) {
+        return (isInvertedY ? originalY*(1/scale) : originalY*scale);
+    }
+
+    function respectUpperBound (value, max) {
+        return (max ? Math.min(max, value) : value);
+    }
+
+    function respectLowerBound (value, min) {
+        return (min ? Math.max(min, value) : value);
+    }
+
+    function updateThreshCount (min, max, target, threshCount) {
+        if (target === max || target === min) {
+            return threshCount+1;
+        }
+        else {
+            return 0;
+        }
+    }
+
+    function signalLimitHitX() {
+        if (targetX === maxX) {
+            maxHitX()
+        }
+        if (targetX === minX) {
+            minHitX()
+        }
+    }
+
+    function signalLimitHitY() {
+        if (targetY === maxY) {
+            maxHitY()
+        }
+        if (targetY === minY) {
+            minHitY()
+        }
+    }
+
+    onPinchUpdated: {
+        if (targetX !== null && isZoomAlongX(pinch.angle)) {
+            updateTargetX(respectLowerBound(respectUpperBound(scaledX(pinch.scale), maxX), minX));
+            threshCountX = updateThreshCount(minX, maxX, targetX, threshCountX);
+
+            if (threshCountX > threshold) {
+                signalLimitHitX();
+                threshCountX /= 2;
+            }
+        }
+
+        if (targetY !== null && !isZoomAlongX()) {
+            updateTargetY(respectLowerBound(respectUpperBound(scaledY(pinch.scale), maxY), minY));
+            threshCountY = updateThreshCount(minY, maxY, targetY, threshCountY);
+
+            if (threshCountY > threshold) {
+                signalLimitHitY();
+                threshCountY /= 2;
+            }
+        }
+    }
+
+    onPinchStarted: {
+        originalX = targetX;
+        originalY = targetY;
+    }
+}

--- a/qml/PinchAreaBase.qml
+++ b/qml/PinchAreaBase.qml
@@ -33,6 +33,10 @@ PinchArea {
         return ( (angle < 45 && angle > -45) || (angle > 135 || angle < -135) );
     }
 
+    function isZoomAlongY(angle) {
+        return ( (angle > 45 && angle < 135) || (angle < -45 && angle > -135) );
+    }
+
     function scaledX(scale) {
         return (isInvertedX ? originalX*(1/scale) : originalX*scale);
     }
@@ -87,7 +91,7 @@ PinchArea {
             }
         }
 
-        if (targetY !== null && !isZoomAlongX()) {
+        if (targetY !== null && isZoomAlongY(pinch.angle)) {
             updateTargetY(respectLowerBound(respectUpperBound(scaledY(pinch.scale), maxY), minY));
             threshCountY = updateThreshCount(minY, maxY, targetY, threshCountY);
 

--- a/qml/PinchAreaBase.qml
+++ b/qml/PinchAreaBase.qml
@@ -19,6 +19,8 @@ PinchArea {
     property int threshCountY: 0
     property bool isInvertedX: false
     property bool isInvertedY: false
+    property bool zoomAlongX: false
+    property bool zoomAlongY: false
 
     readonly property int threshold: 20
 
@@ -81,7 +83,7 @@ PinchArea {
     }
 
     onPinchUpdated: {
-        if (targetX !== null && isZoomAlongX(pinch.angle)) {
+        if (zoomAlongX) {
             updateTargetX(respectLowerBound(respectUpperBound(scaledX(pinch.scale), maxX), minX));
             threshCountX = updateThreshCount(minX, maxX, targetX, threshCountX);
 
@@ -91,7 +93,7 @@ PinchArea {
             }
         }
 
-        if (targetY !== null && isZoomAlongY(pinch.angle)) {
+        if (zoomAlongY) {
             updateTargetY(respectLowerBound(respectUpperBound(scaledY(pinch.scale), maxY), minY));
             threshCountY = updateThreshCount(minY, maxY, targetY, threshCountY);
 
@@ -103,7 +105,20 @@ PinchArea {
     }
 
     onPinchStarted: {
+        if (targetX !== null && isZoomAlongX(pinch.angle)) {
+            zoomAlongX = true;
+        }
+
+        if (targetY !== null && isZoomAlongY(pinch.angle)) {
+            zoomAlongY = true;
+        }
+
         originalX = targetX;
         originalY = targetY;
+    }
+
+    onPinchFinished: {
+        zoomAlongX = false;
+        zoomAlongY = false;
     }
 }

--- a/qml/TimeLineBackground.qml
+++ b/qml/TimeLineBackground.qml
@@ -25,7 +25,7 @@ Column {
         model: 24 // hour in a day
         delegate: Item {
             width: parent.width
-            height: units.gu(8)
+            height: hourItemHeight
 
             SimpleDivider{}
         }

--- a/qml/TimeLineBackground.qml
+++ b/qml/TimeLineBackground.qml
@@ -22,10 +22,18 @@ import Ubuntu.Components 1.3
 Column {
     width: parent.width
     Repeater {
-        model: 24 // hour in a day
+        model: 24 // hours in day
         delegate: Item {
+
             width: parent.width
             height: hourItemHeight
+
+            Rectangle {
+                height: parent.height
+                width: parent.width
+                color: (index < settings.businessHourStart || index > settings.businessHourEnd) ? "#ffffff" : "#efefef"
+                z: -1000 // its the background
+            }
 
             SimpleDivider{}
         }

--- a/qml/TimeLineBase.qml
+++ b/qml/TimeLineBase.qml
@@ -54,7 +54,8 @@ Item {
 
     function getTimeFromYPos(y, day) {
         var date = new Date(day);
-        var time = y / hourHeight;
+        // add 1 to y in order to avoid rounding errors
+        var time = (y+1) / hourHeight;
         var minutes = time % 1 ;
         var hour = time - minutes;
         minutes = parseInt(60 * minutes);

--- a/qml/TimeLineBase.qml
+++ b/qml/TimeLineBase.qml
@@ -31,7 +31,7 @@ Item {
     property alias model: modelConnections.target
     property var flickable: null
     readonly property alias creatingEvent: overlayMouseArea.creatingEvent
-    property real hourHeight: units.gu(8)
+    property real hourHeight: units.gu(4)
     readonly property real minuteHeight: (hourHeight / 60)
 
     signal pressAndHoldAt(var date)
@@ -202,6 +202,9 @@ Item {
     }
 
     function showSeparator() {
+        if (bubbleOverLay.day === undefined) {
+            return;
+        }
         intern.now = new Date();
         if (intern.now.isSameDay(bubbleOverLay.day) ) {
             var y = ((intern.now.getMinutes() * hourHeight) / 60) + intern.now.getHours() * hourHeight;
@@ -213,6 +216,7 @@ Item {
     }
 
     onDayChanged: bubbleOverLay.idleCreateEvents();
+    onHourHeightChanged: bubbleOverLay.showSeparator();
     Component.onCompleted: bubbleOverLay.idleCreateEvents();
     enabled: !intern.busy && !intern.waitingForModelChange
 

--- a/qml/TimeLineBase.qml
+++ b/qml/TimeLineBase.qml
@@ -111,7 +111,7 @@ Item {
         var eventWidth =  (bubbleOverLay.width * eventInfo.width)
 
         eventBubble.anchorDate = bubbleOverLay.day
-        eventBubble.minuteHeight = bubbleOverLay.minuteHeight
+        eventBubble.minuteHeight = Qt.binding(function() { return bubbleOverLay.minuteHeight; });
         eventBubble.sizeOfRow = eventInfo.width
         eventBubble.depthInRow = eventInfo.y
         eventBubble.model = bubbleOverLay.model

--- a/qml/TimeLineBase.qml
+++ b/qml/TimeLineBase.qml
@@ -31,7 +31,7 @@ Item {
     property alias model: modelConnections.target
     property var flickable: null
     readonly property alias creatingEvent: overlayMouseArea.creatingEvent
-    readonly property real hourHeight: units.gu(8)
+    property real hourHeight: units.gu(8)
     readonly property real minuteHeight: (hourHeight / 60)
 
     signal pressAndHoldAt(var date)

--- a/qml/TimeLineBaseComponent.qml
+++ b/qml/TimeLineBaseComponent.qml
@@ -42,6 +42,8 @@ Item {
     property real daysViewed: 5.1
 
     property real hourItemHeight: units.gu(4)
+    property real hourItemHeightMin: Math.max(timeLine.timeLabelHeight, timeLine.height/24)
+
     readonly property int currentHour: timeLineView.contentY > hourItemHeight ?
                                            Math.round(timeLineView.contentY / hourItemHeight) : 1
     readonly property int currentDayOfWeek: timeLineView.contentX > timeLineView.delegateWidth ?
@@ -136,10 +138,6 @@ Item {
     function update()
     {
         mainModel.updateIfNecessary()
-    }
-
-    function getMinHourItemHeight() {
-        return timeLine.getLabelHeight();
     }
 
     Connections{

--- a/qml/TimeLineBaseComponent.qml
+++ b/qml/TimeLineBaseComponent.qml
@@ -39,6 +39,7 @@ Item {
     property alias autoUpdate: mainModel.active
     property var modelFilter: invalidFilter
     property var selectedDay;
+    property real daysViewed: 5.1
 
     readonly property real hourItemHeight: units.gu(8)
     readonly property int currentHour: timeLineView.contentY > hourItemHeight ?
@@ -209,7 +210,7 @@ Item {
             type: root.type
             isActive: root.isActive
             selectedDay: root.selectedDay
-            property double daysViewed: weekViewPath.daysViewed
+            property double daysViewed: root.daysViewed
 
             onDateSelected: {
                 root.dateSelected(date.getFullYear(),
@@ -254,10 +255,9 @@ Item {
 
                 boundsBehavior: Flickable.StopAtBounds
 
-                property double daysViewed: weekViewPath.daysViewed
                 property int delegateWidth: {
                     if( type == ViewType.ViewTypeWeek ) {
-                        width/daysViewed
+                        width/root.daysViewed
                     } else {
                         width
                     }

--- a/qml/TimeLineBaseComponent.qml
+++ b/qml/TimeLineBaseComponent.qml
@@ -196,7 +196,7 @@ Item {
 
         onStartPeriodChanged: idleRefresh.reset()
         onEndPeriodChanged: idleRefresh.reset()
-   }
+    }
 
     Column {
         anchors.fill: parent
@@ -209,6 +209,7 @@ Item {
             type: root.type
             isActive: root.isActive
             selectedDay: root.selectedDay
+            property double daysViewed: weekViewPath.daysViewed
 
             onDateSelected: {
                 root.dateSelected(date.getFullYear(),
@@ -253,9 +254,10 @@ Item {
 
                 boundsBehavior: Flickable.StopAtBounds
 
+                property double daysViewed: weekViewPath.daysViewed
                 property int delegateWidth: {
                     if( type == ViewType.ViewTypeWeek ) {
-                        width/3 - units.gu(1) // partial visible area
+                        width/daysViewed
                     } else {
                         width
                     }
@@ -277,6 +279,7 @@ Item {
                 Row {
                     id: week
                     anchors.fill: parent
+
                     Repeater {
                         model: type == ViewType.ViewTypeWeek ? 7 : 1
 

--- a/qml/TimeLineBaseComponent.qml
+++ b/qml/TimeLineBaseComponent.qml
@@ -41,7 +41,7 @@ Item {
     property var selectedDay;
     property real daysViewed: 5.1
 
-    readonly property real hourItemHeight: units.gu(8)
+    property real hourItemHeight: units.gu(4)
     readonly property int currentHour: timeLineView.contentY > hourItemHeight ?
                                            Math.round(timeLineView.contentY / hourItemHeight) : 1
     readonly property int currentDayOfWeek: timeLineView.contentX > timeLineView.delegateWidth ?
@@ -138,6 +138,10 @@ Item {
         mainModel.updateIfNecessary()
     }
 
+    function getMinHourItemHeight() {
+        return timeLine.getLabelHeight();
+    }
+
     Connections{
         target: keyboardEventProvider
         onScrollUp:{
@@ -150,7 +154,7 @@ Item {
 
         onScrollDown:{
             scrollHour++;
-            var visibleHour = root.height / units.gu(8);
+            var visibleHour = root.height / root.hourItemHeight;
             if( scrollHour > (25 -visibleHour)) {
                 scrollHour = 25 - visibleHour;
             }
@@ -159,7 +163,7 @@ Item {
     }
 
     function scrollToHour() {
-        timeLineView.contentY = scrollHour * units.gu(8);
+        timeLineView.contentY = scrollHour * root.hourItemHeight;
         if(timeLineView.contentY >= timeLineView.contentHeight - timeLineView.height) {
             timeLineView.contentY = timeLineView.contentHeight - timeLineView.height
         }
@@ -185,6 +189,7 @@ Item {
         onTriggered: {
             mainModel.filter = Qt.binding(function() { return root.modelFilter} )
         }
+
     }
 
     EventListModel {
@@ -199,6 +204,7 @@ Item {
         onEndPeriodChanged: idleRefresh.reset()
     }
 
+
     Column {
         anchors.fill: parent
 
@@ -210,7 +216,7 @@ Item {
             type: root.type
             isActive: root.isActive
             selectedDay: root.selectedDay
-            property double daysViewed: root.daysViewed
+            property real daysViewed: root.daysViewed
 
             onDateSelected: {
                 root.dateSelected(date.getFullYear(),
@@ -238,7 +244,9 @@ Item {
             height: parent.height - header.height
 
             TimeLineTimeScale{
+                id: timeLine
                 contentY: timeLineView.contentY
+                hourItemHeight: root.hourItemHeight
             }
 
             SimpleDivider{
@@ -263,7 +271,7 @@ Item {
                     }
                 }
 
-                contentHeight: units.gu(8) * 24
+                contentHeight: root.hourItemHeight * 24
                 contentWidth: {
                     if( type == ViewType.ViewTypeWeek ) {
                         delegateWidth*7
@@ -274,7 +282,9 @@ Item {
 
                 clip: true
 
-                TimeLineBackground{}
+                TimeLineBackground {
+                    property real hourItemHeigth: root.hourItemHeight
+                }
 
                 Row {
                     id: week
@@ -289,6 +299,7 @@ Item {
                             objectName: "TimeLineBase_" + root.objectName
 
                             property int idx: index
+                            hourHeight: root.hourItemHeight
                             flickable: timeLineView
                             anchors.top: parent.top
                             width: {
@@ -343,8 +354,8 @@ Item {
                                     var eventBubble = drag.source;
                                     eventBubble.updateEventBubbleStyle();
 
-                                    if( eventBubble.y + eventBubble.height + units.gu(8) > timeLineView.contentY + timeLineView.height ) {
-                                        var diff = Math.abs((eventBubble.y + eventBubble.height + units.gu(8))  -
+                                    if( eventBubble.y + eventBubble.height + root.hourItemHeight > timeLineView.contentY + timeLineView.height ) {
+                                        var diff = Math.abs((eventBubble.y + eventBubble.height + root.hourItemHeight)  -
                                                             (timeLineView.height + timeLineView.contentY));
                                         timeLineView.contentY += diff
 
@@ -353,8 +364,8 @@ Item {
                                         }
                                     }
 
-                                    if(eventBubble.y - units.gu(8) < timeLineView.contentY ) {
-                                        var diff = Math.abs((eventBubble.y - units.gu(8))  - timeLineView.contentY);
+                                    if(eventBubble.y - root.hourItemHeight < timeLineView.contentY ) {
+                                        var diff = Math.abs((eventBubble.y - root.hourItemHeight)  - timeLineView.contentY);
                                         timeLineView.contentY -= diff
 
                                         if(timeLineView.contentY <= 0) {

--- a/qml/TimeLineBaseComponent.qml
+++ b/qml/TimeLineBaseComponent.qml
@@ -43,6 +43,7 @@ Item {
 
     property real hourItemHeight: units.gu(4)
     property real hourItemHeightMin: Math.max(timeLine.timeLabelHeight, timeLine.height/24)
+    property real headerHeight: 0
 
     onHourItemHeightChanged: {
         keepScrollHourInBounds();
@@ -243,6 +244,7 @@ Item {
                 id: timeLine
                 contentY: timeLineView.contentY
                 hourItemHeight: root.hourItemHeight
+                headerHeight: header.height + root.headerHeight
             }
 
             SimpleDivider{

--- a/qml/TimeLineBaseComponent.qml
+++ b/qml/TimeLineBaseComponent.qml
@@ -45,7 +45,6 @@ Item {
     property real hourItemHeightMin: Math.max(timeLine.timeLabelHeight, timeLine.height/24)
 
     onHourItemHeightChanged: {
-        mainModel.update();
         keepScrollHourInBounds();
     }
 

--- a/qml/TimeLineBaseComponent.qml
+++ b/qml/TimeLineBaseComponent.qml
@@ -43,6 +43,13 @@ Item {
 
     property real hourItemHeight: units.gu(4)
     property real hourItemHeightMin: Math.max(timeLine.timeLabelHeight, timeLine.height/24)
+    property real hourItemHeightPrev: hourItemHeight
+
+    onHourItemHeightChanged: {
+        timeLineView.contentY += timeLineView.contentY * (hourItemHeight - hourItemHeightPrev) / (hourItemHeightPrev);
+        hourItemHeightPrev = hourItemHeight;
+        timeLineView.update();
+    }
 
     readonly property int currentHour: timeLineView.contentY > hourItemHeight ?
                                            Math.round(timeLineView.contentY / hourItemHeight) : 1

--- a/qml/TimeLineHeader.qml
+++ b/qml/TimeLineHeader.qml
@@ -142,7 +142,7 @@ Column {
             interactive: false
 
             property int delegateWidth: {
-                width/3 - units.gu(1) /*partial visible area*/
+                width/headerRoot.daysViewed
             }
             contentHeight: height
             contentWidth: {

--- a/qml/TimeLineTimeScale.qml
+++ b/qml/TimeLineTimeScale.qml
@@ -22,7 +22,8 @@ import Ubuntu.Components 1.3
 Flickable{
     id: timeFlickble
 
-    property real hourItemHeight: units.gu(8)
+    property real timeLabelHeight: 0
+    property real hourItemHeight: units.gu(4)
 
     height: parent.height
     width: units.gu(6)
@@ -54,14 +55,16 @@ Flickable{
                     text: Qt.formatTime( new Date(0,0,0,index), "hh:mm")
                     color: UbuntuColors.lightGrey
                     fontSize: "small"
+
+                    Binding{
+                        target: timeFlickble
+                        property: "timeLabelHeight"
+                        value: timeLabel.height+2*timeLabel.anchors.topMargin
+                    }
                 }
 
                 SimpleDivider{}
             }
         }
-    }
-
-    function getLabelHeight() {
-        return timeLabel.height;
     }
 }

--- a/qml/TimeLineTimeScale.qml
+++ b/qml/TimeLineTimeScale.qml
@@ -24,6 +24,7 @@ Flickable{
 
     property real timeLabelHeight: 0
     property real hourItemHeight: units.gu(4)
+    property real headerHeight
 
     height: parent.height
     width: units.gu(6)
@@ -34,6 +35,70 @@ Flickable{
     interactive: false
 
     clip: true
+
+    function yToHour (height) {
+        return (contentY + (height - headerHeight)) / hourItemHeight;
+    }
+
+
+    MultiPointTouchArea {
+        id: businessHourSetter
+
+        property bool isStatic: true
+        property real staticTolerance: units.gu(0.01)
+        property var startPoint1;
+        property var startPoint2;
+
+        minimumTouchPoints: 2
+        maximumTouchPoints: 2
+        anchors.fill: parent
+
+        onPressed: {
+            startPoint1 = Qt.point(touchPoints[0].sceneX, touchPoints[0].sceneY);
+            startPoint2 = Qt.point(touchPoints[1].sceneX, touchPoints[1].sceneY);
+
+            touchTimer.wasLong = false;
+            isStatic = true;
+
+            touchTimer.restart()
+        }
+
+        onUpdated: {
+            touchPoints.forEach( function(entry) {
+                if (manhattanDistance(Qt.point(entry.x, entry.y), Qt.point(entry.startX, entry.startY)) > staticTolerance) {
+                    isStatic = false;
+                }
+            });
+        }
+
+        onReleased: {
+            touchTimer.stop();
+        }
+
+        Timer {
+            id: touchTimer
+            property bool wasLong: false
+
+            interval: 1000
+            repeat: false
+            onTriggered: {
+                if (businessHourSetter.isStatic) {
+                    wasLong = true;
+
+                    var newBusinessHourStart = yToHour(Math.min(businessHourSetter.startPoint1.y, businessHourSetter.startPoint2.y));
+                    var newBusinessHourEnd = yToHour(Math.max(businessHourSetter.startPoint1.y, businessHourSetter.startPoint2.y));
+
+                    settings.businessHourStart = newBusinessHourStart;
+                    settings.businessHourEnd = newBusinessHourEnd;
+                }
+            }
+        }
+
+        function manhattanDistance(point1, point2) {
+            var diff = Qt.point(point1.x - point2.x, point1.y - point2.y);
+            return Math.abs(diff.x) + Math.abs(diff.y);
+        }
+    }
 
     Column {
         id: timeLine

--- a/qml/TimeLineTimeScale.qml
+++ b/qml/TimeLineTimeScale.qml
@@ -22,10 +22,12 @@ import Ubuntu.Components 1.3
 Flickable{
     id: timeFlickble
 
+    property real hourItemHeight: units.gu(8)
+
     height: parent.height
     width: units.gu(6)
 
-    contentHeight: 24 * units.gu(8)
+    contentHeight: 24 * hourItemHeight
     contentWidth: width
 
     interactive: false
@@ -41,7 +43,7 @@ Flickable{
 
             delegate: Item {
                 width: parent.width
-                height: units.gu(8)
+                height: hourItemHeight
 
                 Label {
                     id: timeLabel
@@ -57,5 +59,9 @@ Flickable{
                 SimpleDivider{}
             }
         }
+    }
+
+    function getLabelHeight() {
+        return timeLabel.height;
     }
 }

--- a/qml/WeekView.qml
+++ b/qml/WeekView.qml
@@ -163,39 +163,15 @@ PageWithBottomEdge {
     }
 
     // Zoom along the x-axis in WeekView adjusts number of days viewed
-    PinchArea {
-        enabled: true
+    PinchAreaBase {
         id: daysInWeekViewScaler
-        anchors.fill: parent
-        pinch.minimumRotation: 0
-        pinch.maximumRotation: 0
-        pinch.minimumScale: 1
-        pinch.maximumScale: 10
-        pinch.dragAxis: Pinch.XAxis
+        targetX: weekViewPath.daysViewed
+        isInvertedX: true
+        minX: 1
+        maxX: 6.9
 
-        property double daysViewedBeforePinch
-        property int threshing: 0
-        readonly property int threshold: 20
-
-        onPinchStarted: {
-            daysViewedBeforePinch = weekViewPath.daysViewed
-
-        }
-
-        onPinchUpdated: {
-            weekViewPath.daysViewed = Math.max(1, Math.min((1/pinch.scale)*daysViewedBeforePinch, 6.9)) // 6.9 dirty fix to be able to scroll to next week
-            if (weekViewPath.daysViewed === 6.9) {
-                threshing++;
-            }
-            else {
-                threshing = 0;
-            }
-
-            if (threshing > threshold) {
-                tabs.selectedTabIndex = monthTab.index;
-                threshing = threshold/2;
-            }
-        }
+        onUpdateTargetX: { weekViewPath.daysViewed = targetX; }
+        onMaxHitX: { tabs.selectedTabIndex = monthTab.index; }
 
         PathViewBase {
             id: weekViewPath

--- a/qml/WeekView.qml
+++ b/qml/WeekView.qml
@@ -190,7 +190,7 @@ PageWithBottomEdge {
             }
 
             //This is used to scroll all view together when currentItem scrolls
-            property var childContentY;
+            property real childScrollHour;
             property real daysViewed: 5.1
             property real hourItemHeight: units.gu(4)
 
@@ -279,18 +279,19 @@ PageWithBottomEdge {
                         //get contentY value from PathView, if its not current Item
                         Binding{
                             target: timeLineView
-                            property: "contentY"
-                            value: weekViewPath.childContentY;
-                            when: !parent.PathView.isCurrentItem
+                            property: "scrollHour"
+                            value: weekViewPath.childScrollHour;
+                            when: !timeLineView.isCurrentItem
                         }
 
                         //set PathView's contentY property, if its current item
                         Binding{
                             target: weekViewPath
-                            property: "childContentY"
-                            value: contentY
-                            when: parent.PathView.isCurrentItem
+                            property: "childScrollHour"
+                            value: timeLineView.scrollHour
+                            when: timeLineView.isCurrentItem
                         }
+
                         Binding {
                             target: weekViewPath
                             property: "interactive"

--- a/qml/WeekView.qml
+++ b/qml/WeekView.qml
@@ -162,9 +162,8 @@ PageWithBottomEdge {
         flickable: null
     }
 
-    // Zoom along the x-axis in WeekView adjusts number of days viewed
     PinchAreaBase {
-        id: daysInWeekViewScaler
+        id: weekViewPinch
 
         targetX: weekViewPath.daysViewed
         isInvertedX: true
@@ -218,7 +217,7 @@ PageWithBottomEdge {
                         selectedDay: weekViewPage.selectedDay
                         modelFilter: weekViewPage.model ? weekViewPage.model.filter : null
                         daysViewed: weekViewPath.daysViewed
-                        hourItemHeight: weekViewPath.hourItemHeight
+                        hourItemHeight: Math.max(weekViewPath.hourItemHeight, timeLineView.hourItemHeightMin)
 
                         onDateSelected: {
                             weekViewPage.dateSelected(date);
@@ -296,6 +295,13 @@ PageWithBottomEdge {
                             target: weekViewPath
                             property: "interactive"
                             value: timeLineView.contentInteractive
+                        }
+
+                        Binding{
+                            target: weekViewPinch
+                            property: "minY"
+                            value: timeLineView.hourItemHeightMin
+                            when: timeLineView.isCurrentItem
                         }
                     }
                 }

--- a/qml/WeekView.qml
+++ b/qml/WeekView.qml
@@ -218,6 +218,7 @@ PageWithBottomEdge {
                         modelFilter: weekViewPage.model ? weekViewPage.model.filter : null
                         daysViewed: weekViewPath.daysViewed
                         hourItemHeight: Math.max(weekViewPath.hourItemHeight, timeLineView.hourItemHeightMin)
+                        headerHeight: weekViewPath.anchors.topMargin
 
                         onDateSelected: {
                             weekViewPage.dateSelected(date);

--- a/qml/WeekView.qml
+++ b/qml/WeekView.qml
@@ -165,13 +165,16 @@ PageWithBottomEdge {
     // Zoom along the x-axis in WeekView adjusts number of days viewed
     PinchAreaBase {
         id: daysInWeekViewScaler
+
         targetX: weekViewPath.daysViewed
         isInvertedX: true
         minX: 1
         maxX: 6.9
-
         onUpdateTargetX: { weekViewPath.daysViewed = targetX; }
         onMaxHitX: { tabs.selectedTabIndex = monthTab.index; }
+
+        targetY: weekViewPath.hourItemHeight
+        onUpdateTargetY: { weekViewPath.hourItemHeight = targetY; }
 
         PathViewBase {
             id: weekViewPath
@@ -190,6 +193,7 @@ PageWithBottomEdge {
             //This is used to scroll all view together when currentItem scrolls
             property var childContentY;
             property real daysViewed: 5.1
+            property real hourItemHeight: units.gu(4)
 
             delegate: Loader {
                 id: timelineLoader
@@ -214,6 +218,7 @@ PageWithBottomEdge {
                         selectedDay: weekViewPage.selectedDay
                         modelFilter: weekViewPage.model ? weekViewPage.model.filter : null
                         daysViewed: weekViewPath.daysViewed
+                        hourItemHeight: weekViewPath.hourItemHeight
 
                         onDateSelected: {
                             weekViewPage.dateSelected(date);

--- a/qml/WeekView.qml
+++ b/qml/WeekView.qml
@@ -162,8 +162,9 @@ PageWithBottomEdge {
         flickable: null
     }
 
-
+    // Zoom along the x-axis in WeekView adjusts number of days viewed
     PinchArea {
+        enabled: true
         id: daysInWeekViewScaler
         anchors.fill: parent
         pinch.minimumRotation: 0
@@ -173,13 +174,27 @@ PageWithBottomEdge {
         pinch.dragAxis: Pinch.XAxis
 
         property double daysViewedBeforePinch
+        property int threshing: 0
+        readonly property int threshold: 20
 
         onPinchStarted: {
             daysViewedBeforePinch = weekViewPath.daysViewed
+
         }
 
         onPinchUpdated: {
-            weekViewPath.daysViewed = Math.max(1, Math.min(pinch.scale*daysViewedBeforePinch, 7))
+            weekViewPath.daysViewed = Math.max(1, Math.min((1/pinch.scale)*daysViewedBeforePinch, 6.9)) // 6.9 dirty fix to be able to scroll to next week
+            if (weekViewPath.daysViewed === 6.9) {
+                threshing++;
+            }
+            else {
+                threshing = 0;
+            }
+
+            if (threshing > threshold) {
+                tabs.selectedTabIndex = monthTab.index;
+                threshing = threshold/2;
+            }
         }
 
         PathViewBase {
@@ -198,7 +213,7 @@ PageWithBottomEdge {
 
             //This is used to scroll all view together when currentItem scrolls
             property var childContentY;
-            property double daysViewed: 5.1
+            property real daysViewed: 5.1
 
             delegate: Loader {
                 id: timelineLoader
@@ -222,6 +237,7 @@ PageWithBottomEdge {
                         keyboardEventProvider: weekViewPath
                         selectedDay: weekViewPage.selectedDay
                         modelFilter: weekViewPage.model ? weekViewPage.model.filter : null
+                        daysViewed: weekViewPath.daysViewed
 
                         onDateSelected: {
                             weekViewPage.dateSelected(date);

--- a/qml/calendar.qml
+++ b/qml/calendar.qml
@@ -29,6 +29,8 @@ MainView {
     property bool displayWeekNumber: false;
     property bool displayLunarCalendar: false;
     property int reminderDefaultValue: 900;
+    property int businessHourStart: 8;
+    property int businessHourEnd: 16;
     readonly property bool syncInProgress: commonHeaderActions.syncInProgress
 
     function handleUri(uri)
@@ -298,6 +300,8 @@ MainView {
             property alias showWeekNumber: mainView.displayWeekNumber
             property alias showLunarCalendar: mainView.displayLunarCalendar
             property alias reminderDefaultValue: mainView.reminderDefaultValue
+            property alias businessHourStart: mainView.businessHourStart
+            property alias businessHourEnd: mainView.businessHourEnd
 
             function defaultViewIndexValue(fallback) {
                 return defaultViewIndex != -1 ? defaultViewIndex : fallback


### PR DESCRIPTION
The background of working hours is drawn in light gray. When tapping on the time scale with two fingers for at least 1 second, the working hours are set. Already tested with nexus 4, meizu pro 5 and lenovo yoga 3 pro. click package can be found here: https://github.com/hummlbach/calendar-app/releases/tag/v0.7.2-beta1.