### PR TITLE
Bump version number

### DIFF
--- a/manifest.json.in
+++ b/manifest.json.in
@@ -18,7 +18,7 @@
     "maintainer": "UBports <dev@ubports.com>",
     "name": "@PROJECT_NAME@",
     "title": "Calendar",
-    "version": "0.7.0",
+    "version": "0.7.1",
     "x-test": {
         "autopilot": {
             "autopilot_module": "@AUTOPILOT_DIR@",


### PR DESCRIPTION
This is required to get the last two commits into the OpenStore.