### PR TITLE
Issue 81: make times respecting the locale

### DIFF
--- a/po/com.ubuntu.calendar.pot
+++ b/po/com.ubuntu.calendar.pot
@@ -1,6 +1,6 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the PACKAGE package.
+# This file is distributed under the same license as the com.ubuntu.calendar package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 #, fuzzy
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.ubuntu.calendar\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-06-17 00:58+0000\n"
+"POT-Creation-Date: 2018-07-14 20:40+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -27,7 +27,7 @@ msgid "Edit"
 msgstr ""
 
 #: ../qml/EventDetails.qml:173 ../qml/TimeLineHeader.qml:66
-#: ../qml/calendar.qml:701
+#: ../qml/calendar.qml:705
 msgid "All Day"
 msgstr ""
 
@@ -87,8 +87,8 @@ msgstr ""
 
 #: ../qml/ColorPickerDialog.qml:55 ../qml/NewEvent.qml:387
 #: ../qml/DeleteConfirmationDialog.qml:60
-#: ../qml/EditEventConfirmationDialog.qml:53
-#: ../qml/OnlineAccountsHelper.qml:73 ../qml/RemindersPage.qml:72
+#: ../qml/EditEventConfirmationDialog.qml:53 ../qml/OnlineAccountsHelper.qml:73
+#: ../qml/RemindersPage.qml:72
 msgid "Cancel"
 msgstr ""
 
@@ -311,7 +311,7 @@ msgstr ""
 msgid "Edit this"
 msgstr ""
 
-#: ../qml/AgendaView.qml:50 ../qml/calendar.qml:361 ../qml/calendar.qml:594
+#: ../qml/AgendaView.qml:50 ../qml/calendar.qml:365 ../qml/calendar.qml:598
 msgid "Agenda"
 msgstr ""
 
@@ -389,7 +389,7 @@ msgstr ""
 msgid "Calendars"
 msgstr ""
 
-#: ../qml/CalendarChoicePopup.qml:46 ../qml/SettingsPage.qml:49
+#: ../qml/CalendarChoicePopup.qml:46 ../qml/SettingsPage.qml:51
 msgid "Back"
 msgstr ""
 
@@ -421,23 +421,27 @@ msgstr ""
 msgid "Ok"
 msgstr ""
 
-#: ../qml/EventActions.qml:66 ../qml/SettingsPage.qml:47
+#: ../qml/EventActions.qml:66 ../qml/SettingsPage.qml:49
 msgid "Settings"
 msgstr ""
 
-#: ../qml/SettingsPage.qml:70
+#: ../qml/SettingsPage.qml:72
 msgid "Show week numbers"
 msgstr ""
 
-#: ../qml/SettingsPage.qml:88
+#: ../qml/SettingsPage.qml:90
 msgid "Show lunar calendar"
 msgstr ""
 
-#: ../qml/SettingsPage.qml:136
+#: ../qml/SettingsPage.qml:110
+msgid "Business hours"
+msgstr ""
+
+#: ../qml/SettingsPage.qml:211
 msgid "Default reminder"
 msgstr ""
 
-#: ../qml/SettingsPage.qml:180
+#: ../qml/SettingsPage.qml:255
 msgid "Default calendar"
 msgstr ""
 
@@ -497,26 +501,26 @@ msgstr ""
 msgid "Weekly on %1"
 msgstr ""
 
-#: ../qml/calendar.qml:72
+#: ../qml/calendar.qml:74
 msgid ""
 "Calendar app accept four arguments: --starttime, --endtime, --newevent and --"
 "eventid. They will be managed by system. See the source for a full comment "
 "about them"
 msgstr ""
 
-#: ../qml/calendar.qml:329 ../qml/calendar.qml:510
+#: ../qml/calendar.qml:333 ../qml/calendar.qml:514
 msgid "Year"
 msgstr ""
 
-#: ../qml/calendar.qml:337 ../qml/calendar.qml:531
+#: ../qml/calendar.qml:341 ../qml/calendar.qml:535
 msgid "Month"
 msgstr ""
 
-#: ../qml/calendar.qml:345 ../qml/calendar.qml:552
+#: ../qml/calendar.qml:349 ../qml/calendar.qml:556
 msgid "Week"
 msgstr ""
 
-#: ../qml/calendar.qml:353 ../qml/calendar.qml:573
+#: ../qml/calendar.qml:357 ../qml/calendar.qml:577
 msgid "Day"
 msgstr ""
 

--- a/po/com.ubuntu.calendar.pot
+++ b/po/com.ubuntu.calendar.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.ubuntu.calendar\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-06-09 15:20+0000\n"
+"POT-Creation-Date: 2018-06-17 00:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -27,6 +27,7 @@ msgid "Edit"
 msgstr ""
 
 #: ../qml/EventDetails.qml:173 ../qml/TimeLineHeader.qml:66
+#: ../qml/calendar.qml:701
 msgid "All Day"
 msgstr ""
 
@@ -268,7 +269,7 @@ msgstr ""
 #. TRANSLATORS: this refers to how often a recurrent event repeats
 #. and it is shown as the header of the option selector to choose
 #. its repetition
-#: ../qml/NewEvent.qml:775 ../qml/EventRepetition.qml:247
+#: ../qml/NewEvent.qml:775 ../qml/EventRepetition.qml:279
 msgid "Repeats"
 msgstr ""
 
@@ -448,19 +449,23 @@ msgstr ""
 #. and it is shown as the header of the page to choose repetition
 #. and as the header of the list item that shows the repetition
 #. summary in the page that displays the event details
-#: ../qml/EventRepetition.qml:40 ../qml/EventRepetition.qml:157
+#: ../qml/EventRepetition.qml:40 ../qml/EventRepetition.qml:164
 msgid "Repeat"
 msgstr ""
 
-#: ../qml/EventRepetition.qml:177
+#: ../qml/EventRepetition.qml:184
 msgid "Repeats On:"
 msgstr ""
 
-#: ../qml/EventRepetition.qml:223
+#: ../qml/EventRepetition.qml:230
+msgid "Interval of recurrence"
+msgstr ""
+
+#: ../qml/EventRepetition.qml:255
 msgid "Recurring event ends"
 msgstr ""
 
-#: ../qml/EventRepetition.qml:273
+#: ../qml/EventRepetition.qml:305
 msgid "Date"
 msgstr ""
 

--- a/qml/CustomPickers/1.0/HoursModel.qml
+++ b/qml/CustomPickers/1.0/HoursModel.qml
@@ -21,6 +21,12 @@ PickerModelBase {
     property int from
     circular: count >= 24
 
+    function getHourLocalized(hour) {
+        var date = new Date(0,0,0,hour);
+        var localizedTime = Qt.formatTime(date, Qt.SystemLocaleShortDate);
+        return localizedTime.split(":")[0];
+    }
+
     function reset() {
         resetting = true;
 
@@ -28,7 +34,7 @@ PickerModelBase {
         from = minimum.getHours();
         var distance = (!Date.prototype.isValid.call(maximum) || (minimum.daysTo(maximum) > 1)) ? 24 : minimum.hoursTo(maximum);
         for (var i = 0; i < distance; i++) {
-            append({"hour": (from + i) % 24});
+            append({"hour": getHourLocalized((from + i) % 24)});
         }
 
         resetting = false;

--- a/qml/DayView.qml
+++ b/qml/DayView.qml
@@ -143,7 +143,7 @@ PageWithBottomEdge {
         id: dayViewPinch
 
         // PinchArea not working inside PathView but we don't want to overlap the PinchArea with the TimeLineTimeScale
-        anchors.leftMargin: units.gu(6) // this magic number will be refactored soon
+        anchors.leftMargin: leftColumnContentWithPadding.width
         targetX: 1
         minX: 1
         maxX: 1.1
@@ -167,8 +167,7 @@ PageWithBottomEdge {
                 fill: parent
                 topMargin: header.height
                 bottomMargin: dayViewPage.bottomEdgeHeight
-                // this magic number will be refactored soon
-                leftMargin: -units.gu(6)
+                leftMargin: -leftColumnContentWithPadding.width
             }
 
             delegate: TimeLineBaseComponent {

--- a/qml/TimeLineHeader.qml
+++ b/qml/TimeLineHeader.qml
@@ -44,7 +44,7 @@ Column {
 
         Column{
             id: labelColumn
-            width : units.gu(6)
+            width : leftColumnContentWithPadding.width
 
             Label{
                 id: weekNumLabel

--- a/qml/TimeLineTimeScale.qml
+++ b/qml/TimeLineTimeScale.qml
@@ -27,8 +27,7 @@ Flickable{
     property real headerHeight
 
     height: parent.height
-    width: units.gu(6)
-
+    width: leftColumnContentWithPadding.width
     contentHeight: 24 * hourItemHeight
     contentWidth: width
 
@@ -113,11 +112,12 @@ Flickable{
 
                 Label {
                     id: timeLabel
-                    width: units.gu(5)
+                    width: localizedTimeLabelTemplate.width
                     anchors.top: parent.top
                     anchors.topMargin: units.gu(0.5)
+                    anchors.horizontalCenter: parent.horizontalCenter
                     horizontalAlignment: Text.AlignRight
-                    text: Qt.formatTime( new Date(0,0,0,index), "hh:mm")
+                    text: Qt.formatTime(new Date(0,0,0,index), Qt.SystemLocaleShortDate)
                     color: UbuntuColors.lightGrey
                     fontSize: "small"
 

--- a/qml/WeekView.qml
+++ b/qml/WeekView.qml
@@ -166,7 +166,7 @@ PageWithBottomEdge {
         id: weekViewPinch
 
         // PinchArea not working inside PathView but we don't want to overlap the PinchArea with the TimeLineTimeScale
-        anchors.leftMargin: units.gu(6) // this magic number will be refactored soon
+        anchors.leftMargin: leftColumnContentWithPadding.width
         targetX: weekViewPath.daysViewed
         isInvertedX: true
         minX: 1
@@ -185,8 +185,7 @@ PageWithBottomEdge {
                 fill: parent
                 topMargin: header.height
                 bottomMargin: weekViewPage.bottomEdgeHeight
-                // this magic number will be refactored soon
-                leftMargin: -units.gu(6)
+                leftMargin: -leftColumnContentWithPadding.width
             }
 
             onCurrentIndexChanged: {

--- a/qml/calendar.qml
+++ b/qml/calendar.qml
@@ -690,6 +690,28 @@ MainView {
        }
     }
 
+    Item {
+        id: leftColumnContentWithPadding
+        width: Math.ceil(childrenRect.width/units.gu(1))*units.gu(1) + units.gu(1)
+
+        Label {
+            id: localizedTimeLabelTemplate
+            visible: false
+            fontSize: "small"
+            text: Qt.formatTime(new Date(0,0,0,12), Qt.SystemLocaleShortDate)
+        }
+
+        Repeater {
+            model: i18n.tr("All Day").split(" ")
+
+            Label {
+                text: modelData
+                visible: false
+                fontSize: "small"
+            }
+        }
+    }
+
     Component {
         id: weekViewComp
 


### PR DESCRIPTION
- format the times displayed in the time line column according to the locale
- added item/label template to calendar.qml to calculate time scale column
  width depending on the time label (which itself depends on the locale now)
- Changed CustomPickers HoursModel to respect the locale

click for testing (16.04): https://github.com/hummlbach/calendar-app/releases/download/v0.7.2-beta4/com.ubuntu.calendar_0.7.2-beta4_armhf.click