### PR TITLE
Issue #16: Rename lunar calendar setting to chinese calendar

### DIFF
--- a/po/com.ubuntu.calendar.pot
+++ b/po/com.ubuntu.calendar.pot
@@ -430,7 +430,7 @@ msgid "Show week numbers"
 msgstr ""
 
 #: ../qml/SettingsPage.qml:90
-msgid "Display chinese calendar"
+msgid "Display Chinese calendar"
 msgstr ""
 
 #: ../qml/SettingsPage.qml:110

--- a/po/com.ubuntu.calendar.pot
+++ b/po/com.ubuntu.calendar.pot
@@ -430,7 +430,7 @@ msgid "Show week numbers"
 msgstr ""
 
 #: ../qml/SettingsPage.qml:90
-msgid "Show lunar calendar"
+msgid "Display chinese calendar"
 msgstr ""
 
 #: ../qml/SettingsPage.qml:110

--- a/qml/SettingsPage.qml
+++ b/qml/SettingsPage.qml
@@ -87,7 +87,7 @@ Page {
             height: lunarCalLayout.height + divider.height
             ListItemLayout {
                 id: lunarCalLayout
-                title.text: i18n.tr("Show lunar calendar")
+                title.text: i18n.tr("Display chinese calendar")
                 CheckBox {
                     id: lunarCalCheckBox
                     objectName: "lunarCalCheckbox"

--- a/qml/SettingsPage.qml
+++ b/qml/SettingsPage.qml
@@ -87,7 +87,7 @@ Page {
             height: lunarCalLayout.height + divider.height
             ListItemLayout {
                 id: lunarCalLayout
-                title.text: i18n.tr("Display chinese calendar")
+                title.text: i18n.tr("Display Chinese calendar")
                 CheckBox {
                     id: lunarCalCheckBox
                     objectName: "lunarCalCheckbox"


### PR DESCRIPTION
Option "Show lunar calendar" is renamed to "Display chinese calendar" as it seems to be a little more than what the average western user would call a "lunar calendar".