### PR TITLE
EventListModel: update to latestQtPim

### DIFF
--- a/qml/EventListModel.qml
+++ b/qml/EventListModel.qml
@@ -117,21 +117,23 @@ OrganizerModel {
     }
 
     function getDefaultCollection() {
-        var defaultCol = defaultCollection();
-        if (defaultCol.extendedMetaData("collection-selected") === true) {
-            return defaultCol
-        }
-
+        var defaultColId = defaultCollectionId();
         var cals = getCollections();
+
+        var firstSelectedCollection = null
         for(var i = 0 ; i < cals.length ; ++i) {
             var cal = cals[i]
-            var val = cal.extendedMetaData("collection-selected")
-            if (val === true) {
-                return cal;
+            if (cal.extendedMetaData("collection-selected") === true) {
+                if (!firstSelectedCollection) {
+                    firstSelectedCollection = cal
+                }
+                if (cal.id == defaultColId) {
+                    return cal
+                }
             }
         }
 
-        return cals[0]
+        return firstSelectedCollection ? firstSelectedCollection : cals[0]
     }
 
     function setDefaultCollection( collectionId ) {


### PR DESCRIPTION
The defaultCollection() method does not exist anymore, and has been
replaced by defaultCollectionId().