### PR TITLE
Fix clickable 5.0 compatibility

### DIFF
--- a/clickable.json
+++ b/clickable.json
@@ -1,5 +1,4 @@
 {
   "template": "cmake",
-  "kill": "qmlscene",
-  "sdk": "ubuntu-sdk-16.04"
+  "kill": "qmlscene"
 }


### PR DESCRIPTION
The `sdk` key has been removed in clickable 5.0. Xenial now is the default.